### PR TITLE
Guard removed UIDropDownMenu globals

### DIFF
--- a/GUI_Config.lua
+++ b/GUI_Config.lua
@@ -25,8 +25,8 @@ local IsInInstance = IsInInstance
 local FauxScrollFrame_GetOffset = FauxScrollFrame_GetOffset
 local FauxScrollFrame_OnVerticalScroll = FauxScrollFrame_OnVerticalScroll
 local FauxScrollFrame_Update = FauxScrollFrame_Update
-local UIDropDownMenu_AddButton = UIDropDownMenu_AddButton
-local UIDropDownMenu_SetSelectedID = UIDropDownMenu_SetSelectedID
+local UIDropDownMenu_AddButton = UIDropDownMenu_AddButton or function() end
+local UIDropDownMenu_SetSelectedID = UIDropDownMenu_SetSelectedID or function() end
 
 local GameTooltip = GameTooltip
 

--- a/GUI_Main.lua
+++ b/GUI_Main.lua
@@ -46,8 +46,8 @@ local UIParent = UIParent
 local FauxScrollFrame_GetOffset = FauxScrollFrame_GetOffset
 local FauxScrollFrame_Update = FauxScrollFrame_Update
 local FauxScrollFrame_OnVerticalScroll = FauxScrollFrame_OnVerticalScroll
-local UIDropDownMenu_AddButton = UIDropDownMenu_AddButton
-local UIDropDownMenu_SetAnchor = UIDropDownMenu_SetAnchor
+local UIDropDownMenu_AddButton = UIDropDownMenu_AddButton or function() end
+local UIDropDownMenu_SetAnchor = UIDropDownMenu_SetAnchor or function() end
 
 local WOW_PANDA_CLASSIC = WOW_PROJECT_ID == WOW_PROJECT_MISTS_CLASSIC
 


### PR DESCRIPTION
GUI_Main.lua and GUI_Config.lua localize several UIDropDownMenu_* functions at the top of the file that were removed in Midnight. While the code paths that use them are dead on retail (the addon switched to LibDropdown-1.0 for all active dropdowns), the bare localizations would blow up if the globals don't exist.