### PR TITLE
Fix potential secret value crash in font string width checks

### DIFF
--- a/GUI_Detail.lua
+++ b/GUI_Detail.lua
@@ -476,14 +476,18 @@ function Recount:WrapFontString(fontstring, maxwidth)
 	local Returning = ""
 	local Temp, NextWhite
 
-	while fontstring:GetStringWidth() > maxwidth do
+	local ok, sw = pcall(fontstring.GetStringWidth, fontstring)
+	while ok and type(sw) == "number" and not (issecretvalue and issecretvalue(sw)) and sw > maxwidth do
 		Temp = string.reverse(Text)
 		local _
 		_, NextWhite = string.find(Temp,"( +)")
 
+		if not NextWhite then break end
+
 		Returning = string.sub(Text, string.len(Text) - NextWhite + 1, string.len(Text))..Returning
 		Text = string.sub(Text, 1, string.len(Text) - NextWhite)
 		fontstring:SetText(Text)
+		ok, sw = pcall(fontstring.GetStringWidth, fontstring)
 	end
 	return Returning
 end

--- a/GUI_Graph.lua
+++ b/GUI_Graph.lua
@@ -746,9 +746,11 @@ end
 function Recount:CheckFontStringLength(fontstring, maxwidth)
 	local Text = fontstring:GetText()
 
-	while fontstring:GetStringWidth() > maxwidth do
+	local ok, sw = pcall(fontstring.GetStringWidth, fontstring)
+	while ok and type(sw) == "number" and not (issecretvalue and issecretvalue(sw)) and sw > maxwidth do
 		Text = string.sub(Text, 1, string.len(Text) - 1)
 		fontstring:SetText(Text.."...")
+		ok, sw = pcall(fontstring.GetStringWidth, fontstring)
 	end
 end
 


### PR DESCRIPTION
WrapFontString and CheckFontStringLength both loop comparing GetStringWidth() against a max width. In Midnight, GetStringWidth() can return a secret value in tainted execution contexts, and the > comparison throws an error.

Added the same pcall + issecretvalue guard pattern that's already used in GUI_Main.lua's FixRow function — wrap the call in pcall, check the result is a real number and not secret, bail out of the loop otherwise.