### PR TITLE
Minor cleanup: nil global fallback and leftover debug print

### DIFF
--- a/GUI_Realtime.lua
+++ b/GUI_Realtime.lua
@@ -320,7 +320,6 @@ function me:CreateRealtimeWindow(who, tracking, ending) -- Elsia: This function 
 	theFrame.DragBottomLeft:SetPoint("BOTTOMLEFT", theFrame, "BOTTOMLEFT", 0, 0)
 	theFrame.DragBottomLeft:EnableMouse(true)
 	theFrame.DragBottomLeft:SetScript("OnMouseDown", function(this, button)
-		Recount:DPrint("y")
 		if (((not this:GetParent().isLocked) or (this:GetParent().isLocked == 0)) and (button == "LeftButton")) then
 			this:GetParent().isResizing = true
 			this:GetParent():StartSizing("BOTTOMLEFT")

--- a/Tracker.lua
+++ b/Tracker.lua
@@ -26,7 +26,7 @@ local tonumber = tonumber
 local type = type
 local unpack = unpack
 
-local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
+local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo or (C_CombatLog and C_CombatLog.GetCurrentEventInfo)
 local CreateFrame = CreateFrame
 local DeclineName = DeclineName
 local GetFramerate = GetFramerate


### PR DESCRIPTION
Two small items:

- Tracker.lua localizes CombatLogGetCurrentEventInfo which doesn't exist in Midnight. The code path is dead on retail anyway, but the bare nil reference is messy. Added a compat fallback.
- GUI_Realtime.lua had a stray Recount:DPrint("y") in the bottom-left drag handler that got left behind from debugging. Removed it.