### PR TITLE
Actually invoke OnMouseUp handler after window scale changes

### DIFF
--- a/WindowOrder.lua
+++ b/WindowOrder.lua
@@ -100,7 +100,7 @@ function Recount:ScaleWindows(scale, first)
 
 			if v:GetScript("OnMouseUp") then
 				v.isMoving = true
-				v:GetScript("OnMouseUp")
+				v:GetScript("OnMouseUp")(v, "LeftButton")
 				v.isMoving = false
 			end
 		end


### PR DESCRIPTION
In WindowOrder.lua, when windows are rescaled the code grabs the OnMouseUp to trigger position saving, but it never actually calls the returned function — the result is just silently thrown away. This means window positions aren't properly saved after a scale change.

Fixed by calling the returned handler with (v, "LeftButton") to match the standard OnMouseUp signature. This has been broken since before the Midnight migration.