### PR TITLE
Fix remaining FightingWho secret value crashes

### DIFF
--- a/Fights.lua
+++ b/Fights.lua
@@ -28,7 +28,9 @@ function Fights:MoveFights()
 		for i = math.min(#Recount.db2.FoughtWho, Recount.db.profile.MaxFights - 1), 1, -1 do
 			Recount.db2.FoughtWho[i + 1] = Recount.db2.FoughtWho[i]
 		end
-		Recount.db2.FoughtWho[1] = Recount.FightingWho.." "..Recount.InCombatF.."-"..date("%H:%M:%S")
+		local fwLabel = ""
+		pcall(function() fwLabel = Recount.FightingWho end)
+		Recount.db2.FoughtWho[1] = fwLabel.." "..Recount.InCombatF.."-"..date("%H:%M:%S")
 	end
 
 	for k, v in pairs(Recount.db2.combatants) do

--- a/Recount.lua
+++ b/Recount.lua
@@ -1634,7 +1634,8 @@ function Recount:LeaveCombat(Time)
 	end
 	-- Did we actually fight someone?
 	Recount.InCombat = false
-	if (Recount.FightingWho == "") then
+	local fwOk, fwEmpty = pcall(function() return Recount.FightingWho == "" end)
+	if fwOk and fwEmpty then
 		return
 	end
 	-- Elsia: Only sync for actual fights

--- a/Tracker.lua
+++ b/Tracker.lua
@@ -1824,9 +1824,12 @@ function Recount:BossFightWhoFromFlags(srcFlags, dstFlags, victim, victimGUID)
 		if Recount.IsBoss(victimGUID) then
 			Recount.FightingWho = victim
 			Recount.FightingLevel = -1
-		elseif Recount.FightingWho == "" then
-			Recount.FightingWho = victim
-			Recount.FightingLevel = 1
+		else
+			local fwOk, fwEmpty = pcall(function() return Recount.FightingWho == "" end)
+			if fwOk and fwEmpty then
+				Recount.FightingWho = victim
+				Recount.FightingLevel = 1
+			end
 		end
 	end
 end


### PR DESCRIPTION
- Fixes crash at Recount.lua:1637 in `LeaveCombat` when `FightingWho` is a secret string
- Also guards `FightingWho` usage in `BossFightWhoFromFlags` (Tracker.lua) and `MoveFights` (Fights.lua)

(The previous pull request I submitted only covered Tracker_DamageMeter.lua — these are the remaining unprotected locations)